### PR TITLE
Add validation and tests for CSV reading

### DIFF
--- a/R/clean_temperature.R
+++ b/R/clean_temperature.R
@@ -7,11 +7,32 @@
 #' @return A cleaned data frame with a `datetime` column.
 #' @export
 read_raw_uid_csv <- function(filepath, dt_format = "%Y/%m/%d %H:%M:%S") {
-  readr::read_csv(filepath) |>
-    janitor::clean_names() |>
-    dplyr::mutate(
-      datetime = lubridate::as_datetime(date, format = dt_format)
+  df <- readr::read_csv(filepath) |>
+    janitor::clean_names()
+
+  required_cols <- c(
+    "date", "rfid", "temperature",
+    "session_name", "matrix_name", "zone"
+  )
+
+  missing <- setdiff(required_cols, names(df))
+  if (length(missing) > 0) {
+    stop(
+      "Missing required column(s): ",
+      paste(missing, collapse = ", ")
     )
+  }
+
+  df <- dplyr::mutate(
+    df,
+    datetime = lubridate::as_datetime(date, format = dt_format)
+  )
+
+  if (any(is.na(df$datetime))) {
+    stop("Failed to parse datetime with provided format")
+  }
+
+  return(df)
 }
 
 

--- a/tests/testthat/test_read_raw_uid_csv.R
+++ b/tests/testthat/test_read_raw_uid_csv.R
@@ -1,0 +1,37 @@
+library(testthat)
+
+test_that("read_raw_uid_csv parses datetime and returns columns", {
+  tmp <- withr::local_tempfile(fileext = ".csv")
+  writeLines(c(
+    "Date,RFID,Temperature,Session Name,Matrix Name,Zone",
+    "2025/05/24 11:15:25,ABC123,37.5,session1,matrix1,1"
+  ), tmp)
+
+  df <- read_raw_uid_csv(tmp)
+
+  expect_true(all(c("datetime", "rfid", "temperature", "session_name", "matrix_name", "zone") %in% names(df)))
+  expect_s3_class(df$datetime, "POSIXct")
+  expect_equal(df$rfid[1], "ABC123")
+})
+
+
+test_that("read_raw_uid_csv errors on missing columns", {
+  tmp <- withr::local_tempfile(fileext = ".csv")
+  writeLines(c(
+    "Date,RFID,Temperature,Session Name,Matrix Name",
+    "2025/05/24 11:15:25,ABC123,37.5,session1,matrix1"
+  ), tmp)
+
+  expect_error(read_raw_uid_csv(tmp), "Missing required")
+})
+
+
+test_that("read_raw_uid_csv errors on bad datetime", {
+  tmp <- withr::local_tempfile(fileext = ".csv")
+  writeLines(c(
+    "Date,RFID,Temperature,Session Name,Matrix Name,Zone",
+    "bad-date,ABC123,37.5,session1,matrix1,1"
+  ), tmp)
+
+  expect_error(read_raw_uid_csv(tmp), "Failed to parse datetime")
+})


### PR DESCRIPTION
## Summary
- validate required columns in `read_raw_uid_csv`
- ensure malformed datetimes trigger errors
- add tests for `read_raw_uid_csv`

## Testing
- `Rscript -e 'devtools::test()'` *(fails: package `janitor` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6858bae7e028832690a7628d3ea71b2b